### PR TITLE
add backend to docker compose file

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,13 +1,15 @@
 version: '3'
 services:
-#  kurate:
-#    build:
-#      context: .
-#      dockerfile: Dockerfile
-#    depends_on:
-#      - mariadb
-#    ports:
-#      - "8080:8080"
+  kurate:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    depends_on:
+      - mongo
+    ports:
+      - "8338:8338"
+    networks:
+      - backend_network
   mongo:
     image: mongo
     restart: always
@@ -16,3 +18,9 @@ services:
       MONGO_INITDB_ROOT_PASSWORD: password
     ports:
       - "27017:27017"
+    networks:
+      - backend_network
+
+networks:
+  backend_network:
+    driver: bridge

--- a/backend/src/main/resources/conf/config.json
+++ b/backend/src/main/resources/conf/config.json
@@ -1,6 +1,6 @@
 {
   "http.port": 8338,
   "db.name": "kurate",
-  "db.url": "mongodb://root:password@localhost:27017/?authSource=admin",
+  "db.url": "mongodb://root:password@mongo:27017/?authSource=admin",
   "db.useObjectId": true
 }


### PR DESCRIPTION
this PR adds the backend to the docker compose file so that mongodb and backend can be launched in one go.