### PR TITLE
exclude photos from album overview. just show thumbnails.

### DIFF
--- a/backend/src/main/kotlin/gallery/kurate/server/database/AlbumRepository.kt
+++ b/backend/src/main/kotlin/gallery/kurate/server/database/AlbumRepository.kt
@@ -3,7 +3,6 @@ package gallery.kurate.server.database
 import io.reactivex.Maybe
 import io.reactivex.Single
 import io.vertx.core.json.JsonObject
-import io.vertx.kotlin.core.json.jsonArrayOf
 import io.vertx.kotlin.core.json.jsonObjectOf
 import io.vertx.reactivex.ext.mongo.MongoClient
 


### PR DESCRIPTION
This PR removes photos from the `/api/albums` route. Only one `thumbnails` per album will be returned.